### PR TITLE
feat: adds format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,31 @@
 
 Seed is a CLI tool that helps you quickly create directory structures from a tree representation. Whether you have a tree structure in your clipboard or a file, Seed can instantly "grow" it into a real directory structure.
 
+<!--toc:start-->
+- [Seed 🌱](#seed-🌱)
+  - [Installation](#installation)
+    - [Golang](#golang)
+    - [Homebrew](#homebrew)
+    - [Download Binary](#download-binary)
+  - [Usage](#usage)
+    - [From Clipboard](#from-clipboard)
+    - [From String](#from-string)
+    - [From File](#from-file)
+  - [Input Format](#input-format)
+    - [Using ASCII characters](#using-ascii-characters)
+    - [Using spaces](#using-spaces)
+    - [Using JSON](#using-json)
+  - [Features](#features)
+  - [Contributing](#contributing)
+  - [Todo](#todo)
+  - [License](#license)
+  - [Author](#author)
+  - [Acknowledgments](#acknowledgments)
+<!--toc:end-->
+
 ## Installation
 
-Curently supported is golang, homebrew, and good ol' downloading the binary yourself. More support to come. 
+Currently supported is golang, homebrew, and good ol' downloading the binary yourself. More support to come. 
 
 ### Golang
 
@@ -236,7 +258,13 @@ Contributions are welcome! Please feel free to submit a Pull Request. For major 
 ## Todo
 
 - ~~Implement ability to parse from file path~~
-- Add JSON and YAML support 
+- ~~Add JSON support ~~
+- Increase package manager distribution 
+  - apt
+  - pacman
+  - choco
+  - yum
+- Add YAML support 
 - Support StdIn
 - flag to adjust spacing between 2 and 4 for people who write their own trees with just spaces
 

--- a/README.md
+++ b/README.md
@@ -138,34 +138,83 @@ You can generate this format using:
 - VS Code extensions like "File Tree Generator"
 - Or manually create it following the format above
 
-#### JSON and YAML are coming soon!
+### Using JSON
 
-## Examples
+Seed also accepts JSON input that describes the directory structure. The JSON format should be an array containing directory/file objects and an optional report object:
 
-1. **Basic React Project Structure**
-   ```
-   my-react-app
-   ├── src
-   │   ├── components
-   │   ├── hooks
-   │   ├── utils
-   │   └── App.tsx
-   ├── public
-   │   └── index.html
-   └── package.json
-   ```
+```json
+[
+  {
+    "type": "directory",
+    "name": "my-project",
+    "contents": [
+      {
+        "type": "directory",
+        "name": "src",
+        "contents": [
+          {
+            "type": "file",
+            "name": "main.go"
+          },
+          {
+            "type": "directory",
+            "name": "utils",
+            "contents": [
+              {
+                "type": "file",
+                "name": "helper.go"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "report",
+    "directories": 3,
+    "files": 2
+  }
+]
+```
 
-2. **Simple Node.js Project**
-   ```
-   node-api
-   ├── src
-   │   ├── controllers
-   │   ├── models
-   │   ├── routes
-   │   └── index.js
-   ├── tests
-   └── package.json
-   ```
+Each object in the structure must have:
+- `type`: Either "directory" or "file"
+- `name`: The name of the directory or file
+- `contents`: (Optional) An array of nested files and directories (only valid for directory type)
+
+The report object is *optional* and contains:
+- `directories`: Total number of directories
+- `files`: Total number of files
+
+Seed with throw if the report does not match what was created.
+
+Example usage with JSON:
+
+As string
+```bash
+seed -F json '{"type":"directory","name":"project","contents":[{"type":"file","name":"README.md"}]}'
+# or
+seed --format json '{"type":"directory","name":"project","contents":[{"type":"file","name":"README.md"}]}'
+```
+
+From clipboard
+
+```bash
+seed -F json -c
+# or
+seed --format json -c
+```
+From file
+
+> [!NOTE] 
+> Soon the filetype will be auto selected
+
+```bash
+seed -F json -f path/to/structure.json
+# or
+seed --format json -f path/to/structure.json
+```
 
 ## Features
 

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -1,0 +1,5 @@
+package flags
+
+type Flags struct {
+	Root RootFlags
+}

--- a/cmd/flags/root.go
+++ b/cmd/flags/root.go
@@ -11,11 +11,15 @@ type RootFlags struct {
 
 type Format string
 
-const (
-	Tree Format = "tree"
-	JSON Format = "json"
-	YAML Format = "yaml"
-)
+var Formats = struct {
+	Tree Format
+	JSON Format
+	YAML Format
+}{
+	Tree: "tree",
+	JSON: "json",
+	YAML: "yaml",
+}
 
 func (f Format) String() string {
 	return string(f)
@@ -23,7 +27,7 @@ func (f Format) String() string {
 
 func (f *Format) Set(value string) error {
 	switch Format(value) {
-	case Tree, JSON, YAML:
+	case Formats.Tree, Formats.JSON, Formats.YAML:
 		*f = Format(value)
 		return nil
 	default:

--- a/cmd/flags/root.go
+++ b/cmd/flags/root.go
@@ -1,0 +1,36 @@
+package flags
+
+import "fmt"
+
+type RootFlags struct {
+	FilePath      string
+	Format        Format
+	Silent        bool
+	FromClipboard bool
+}
+
+type Format string
+
+const (
+	Tree Format = "tree"
+	JSON Format = "json"
+	YAML Format = "yaml"
+)
+
+func (f Format) String() string {
+	return string(f)
+}
+
+func (f *Format) Set(value string) error {
+	switch Format(value) {
+	case Tree, JSON, YAML:
+		*f = Format(value)
+		return nil
+	default:
+		return fmt.Errorf("invalid format %q, must be one of: tree, json, yaml", value)
+	}
+}
+
+func (f Format) Type() string {
+	return "format"
+}

--- a/cmd/seed/root.go
+++ b/cmd/seed/root.go
@@ -20,11 +20,11 @@ func init() {
 	// Flags
 	rootCmd.Flags().BoolVarP(&flags.FromClipboard, "clipboard", "c", false, "Use tree structure from clipboard.")
 	rootCmd.Flags().StringVarP(&flags.FilePath, "file", "f", "", "Use tree structure from a file.")
-	// rootCmd.Flags().VarP(&flags.Format, "format", "F", "Format of the input [tree, json, yamlj]") // TODO: implement different parsers
+	rootCmd.Flags().VarP(&flags.Format, "format", "F", "Format of the input [tree, json, yaml]")
 }
 
 var rootCmd = &cobra.Command{
-	Version: "0.1.1",
+	Version: "0.1.1", // unreleased
 	Use:     "seed [string]",
 	Short:   "Plant the seeds of your directory tree 🌱.",
 	Long:    "Seed is a CLI tool that helps you grow directory structures from a tree representation provided via string or clipboard.",

--- a/cmd/seed/root.go
+++ b/cmd/seed/root.go
@@ -4,23 +4,22 @@ import (
 	"fmt"
 	"os"
 
+	cmdFlags "github.com/jpwallace22/seed/cmd/flags"
+	"github.com/jpwallace22/seed/internal/ctx"
 	"github.com/jpwallace22/seed/internal/runner"
 	"github.com/spf13/cobra"
 )
 
-var (
-	flags  runner.RootFlags
-	config runner.Config
-)
+var flags cmdFlags.Flags
 
 func init() {
-	// Config
-	rootCmd.Flags().BoolVarP(&config.Silent, "silent", "s", false, "If true, suppresses all non-essential console output.")
+	// Persistent Flags
+	rootCmd.PersistentFlags().BoolVarP(&flags.Root.Silent, "silent", "s", false, "If true, suppresses all non-essential console output.")
 
-	// Flags
-	rootCmd.Flags().BoolVarP(&flags.FromClipboard, "clipboard", "c", false, "Use tree structure from clipboard.")
-	rootCmd.Flags().StringVarP(&flags.FilePath, "file", "f", "", "Use tree structure from a file.")
-	rootCmd.Flags().VarP(&flags.Format, "format", "F", "Format of the input [tree, json, yaml]")
+	// Command Flags
+	rootCmd.Flags().BoolVarP(&flags.Root.FromClipboard, "clipboard", "c", false, "Use tree structure from clipboard.")
+	rootCmd.Flags().StringVarP(&flags.Root.FilePath, "file", "f", "", "Use tree structure from a file.")
+	rootCmd.Flags().VarP(&flags.Root.Format, "format", "F", "Format of the input [tree, json, yaml]")
 }
 
 var rootCmd = &cobra.Command{
@@ -30,8 +29,9 @@ var rootCmd = &cobra.Command{
 	Long:    "Seed is a CLI tool that helps you grow directory structures from a tree representation provided via string or clipboard.",
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		runner := runner.NewRootRunner(cmd, config.Silent)
-		return runner.Run(flags, args)
+		ctx := ctx.New(cmd, flags)
+		runner := runner.NewRootRunner(cmd, ctx)
+		return runner.Run(args)
 	},
 }
 

--- a/cmd/seed/root_flags.go
+++ b/cmd/seed/root_flags.go
@@ -1,0 +1,35 @@
+package main
+
+import "fmt"
+
+type Format string
+
+const (
+	Tree Format = "tree"
+	JSON Format = "json"
+	YAML Format = "yaml"
+)
+
+func (f Format) String() string {
+	return string(f)
+}
+
+func (f *Format) Set(value string) error {
+	switch Format(value) {
+	case Tree, JSON, YAML:
+		*f = Format(value)
+		return nil
+	default:
+		return fmt.Errorf("invalid format %q, must be one of: tree, json, yaml", value)
+	}
+}
+
+func (f Format) Type() string {
+	return "format"
+}
+
+type RootFlags struct {
+	FilePath      string
+	Format        Format
+	FromClipboard bool
+}

--- a/internal/ctx/ctx.go
+++ b/internal/ctx/ctx.go
@@ -7,21 +7,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type GlobalFlags struct {
+type Config struct {
 	Silent bool
 }
 
 type SeedContext struct {
-	Logger      logger.Logger
-	Cobra       *cobra.Command
-	GlobalFlags GlobalFlags
+	Logger logger.Logger
+	Cobra  *cobra.Command
+	Config Config
 }
 
 func Build(cobra *cobra.Command, silent bool) *SeedContext {
 	return &SeedContext{
 		Cobra:  cobra,
 		Logger: logger.NewLogger(os.Stdin, os.Stderr, silent),
-		GlobalFlags: GlobalFlags{
+		Config: Config{
 			Silent: silent,
 		},
 	}

--- a/internal/ctx/ctx.go
+++ b/internal/ctx/ctx.go
@@ -3,26 +3,21 @@ package ctx
 import (
 	"os"
 
+	"github.com/jpwallace22/seed/cmd/flags"
 	"github.com/jpwallace22/seed/pkg/logger"
 	"github.com/spf13/cobra"
 )
 
-type Config struct {
-	Silent bool
-}
-
 type SeedContext struct {
 	Logger logger.Logger
 	Cobra  *cobra.Command
-	Config Config
+	Flags  flags.Flags
 }
 
-func Build(cobra *cobra.Command, silent bool) *SeedContext {
+func New(cobra *cobra.Command, flags flags.Flags) *SeedContext {
 	return &SeedContext{
 		Cobra:  cobra,
-		Logger: logger.NewLogger(os.Stdin, os.Stderr, silent),
-		Config: Config{
-			Silent: silent,
-		},
+		Logger: logger.NewLogger(os.Stdin, os.Stderr, flags.Root.Silent),
+		Flags:  flags,
 	}
 }

--- a/internal/parser/json_parser.go
+++ b/internal/parser/json_parser.go
@@ -27,35 +27,6 @@ func NewJSONParser(ctx ctx.SeedContext) Parser {
 	return &jsonParser{ctx: ctx}
 }
 
-func (p *jsonParser) validateNode(raw json.RawMessage) error {
-	var node struct {
-		Type     string            `json:"type"`
-		Name     string            `json:"name"`
-		Contents []json.RawMessage `json:"contents,omitempty"`
-	}
-
-	if err := json.Unmarshal(raw, &node); err != nil {
-		return fmt.Errorf("invalid node: %w", err)
-	}
-
-	if node.Type == "" {
-		return fmt.Errorf("missing type field")
-	}
-
-	if node.Name == "" {
-		return fmt.Errorf("missing name field")
-	}
-
-	// Recursively validate contents
-	for _, content := range node.Contents {
-		if err := p.validateNode(content); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (p *jsonParser) ParseTree(jsonStr string) error {
 	if jsonStr == "" {
 		return fmt.Errorf("no tree provided")
@@ -100,6 +71,35 @@ func (p *jsonParser) ParseTree(jsonStr string) error {
 		if dirs != report.Directories || files != report.Files {
 			return fmt.Errorf("file system count mismatch - expected: %d directories and %d files, got: %d directories and %d files",
 				report.Directories, report.Files, dirs, files)
+		}
+	}
+
+	return nil
+}
+
+func (p *jsonParser) validateNode(raw json.RawMessage) error {
+	var node struct {
+		Type     string            `json:"type"`
+		Name     string            `json:"name"`
+		Contents []json.RawMessage `json:"contents,omitempty"`
+	}
+
+	if err := json.Unmarshal(raw, &node); err != nil {
+		return fmt.Errorf("invalid node: %w", err)
+	}
+
+	if node.Type == "" {
+		return fmt.Errorf("missing type field")
+	}
+
+	if node.Name == "" {
+		return fmt.Errorf("missing name field")
+	}
+
+	// Recursively validate contents
+	for _, content := range node.Contents {
+		if err := p.validateNode(content); err != nil {
+			return err
 		}
 	}
 

--- a/internal/parser/json_parser.go
+++ b/internal/parser/json_parser.go
@@ -1,0 +1,142 @@
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/jpwallace22/seed/internal/ctx"
+)
+
+type FileNode struct {
+	Type     string     `json:"type"`
+	Name     string     `json:"name"`
+	Contents []FileNode `json:"contents,omitempty"`
+}
+
+type Report struct {
+	Type        string `json:"type"`
+	Directories int    `json:"directories"`
+	Files       int    `json:"files"`
+}
+
+type jsonParser struct {
+	ctx ctx.SeedContext
+}
+
+func NewJSONParser(ctx ctx.SeedContext) Parser {
+	return &jsonParser{ctx: ctx}
+}
+
+func (p *jsonParser) validateNode(raw json.RawMessage) error {
+	var node struct {
+		Type     string            `json:"type"`
+		Name     string            `json:"name"`
+		Contents []json.RawMessage `json:"contents,omitempty"`
+	}
+
+	if err := json.Unmarshal(raw, &node); err != nil {
+		return fmt.Errorf("invalid node: %w", err)
+	}
+
+	if node.Type == "" {
+		return fmt.Errorf("missing type field")
+	}
+
+	if node.Name == "" {
+		return fmt.Errorf("missing name field")
+	}
+
+	// Recursively validate contents
+	for _, content := range node.Contents {
+		if err := p.validateNode(content); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *jsonParser) ParseTree(jsonStr string) error {
+	if jsonStr == "" {
+		return fmt.Errorf("no tree provided")
+	}
+
+	var nodes []json.RawMessage
+	if err := json.Unmarshal([]byte(jsonStr), &nodes); err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	if len(nodes) == 0 {
+		return fmt.Errorf("empty JSON array")
+	}
+
+	// First validate the root node structure
+	if err := p.validateNode(nodes[0]); err != nil {
+		return fmt.Errorf("failed to parse tree: %w", err)
+	}
+
+	// Then parse into FileNode
+	var rootFileNode FileNode
+	if err := json.Unmarshal(nodes[0], &rootFileNode); err != nil {
+		return fmt.Errorf("failed to parse root node: %w", err)
+	}
+
+	// Convert to TreeNode
+	rootTreeNode := p.fileNodeToTreeNode(&rootFileNode)
+
+	// Create filesystem using the existing function
+	if err := createFileSystem(rootTreeNode, "", p.ctx.Logger); err != nil {
+		return fmt.Errorf("failed to create filesystem: %w", err)
+	}
+
+	// Verify report if present
+	if len(nodes) > 1 {
+		var report Report
+		if err := json.Unmarshal(nodes[1], &report); err != nil {
+			return fmt.Errorf("failed to parse report: %w", err)
+		}
+
+		dirs, files := p.countTreeNodes(rootTreeNode)
+		if dirs != report.Directories || files != report.Files {
+			return fmt.Errorf("file system count mismatch - expected: %d directories and %d files, got: %d directories and %d files",
+				report.Directories, report.Files, dirs, files)
+		}
+	}
+
+	return nil
+}
+
+func (p *jsonParser) fileNodeToTreeNode(node *FileNode) *TreeNode {
+	treeNode := &TreeNode{
+		name:     node.Name,
+		isFile:   node.Type == "file",
+		children: make([]*TreeNode, 0),
+	}
+
+	for i := range node.Contents {
+		childNode := p.fileNodeToTreeNode(&node.Contents[i])
+		treeNode.children = append(treeNode.children, childNode)
+	}
+
+	return treeNode
+}
+
+func (p *jsonParser) countTreeNodes(node *TreeNode) (directories int, files int) {
+	if node == nil {
+		return 0, 0
+	}
+
+	if node.isFile {
+		files = 1
+	} else {
+		directories = 1
+	}
+
+	for _, child := range node.children {
+		d, f := p.countTreeNodes(child)
+		directories += d
+		files += f
+	}
+
+	return directories, files
+}

--- a/internal/parser/json_parser_test.go
+++ b/internal/parser/json_parser_test.go
@@ -245,6 +245,35 @@ func (s *JsonTestSuite) TestMissingFields() {
 	})
 }
 
+func (s *JsonTestSuite) TestWithoutReport() {
+	input := `[
+		{"type":"directory","name":"root","contents":[
+			{"type":"directory","name":"docs","contents":[
+				{"type":"file","name":"readme.md"}
+			]},
+			{"type":"file","name":"config.json"}
+		]}
+	]`
+
+	expectedFiles := []string{
+		"root/docs/readme.md",
+		"root/config.json",
+	}
+	expectedDirs := []string{
+		"root",
+		"root/docs",
+	}
+
+	s.Run("create structure without report section", func() {
+		s.Require().NoError(s.parser.ParseTree(input))
+		s.verifyStructure(expectedFiles, expectedDirs)
+
+		// Verify specific files exist
+		s.FileExists(filepath.Join(s.tempDir, "root/docs/readme.md"))
+		s.FileExists(filepath.Join(s.tempDir, "root/config.json"))
+	})
+}
+
 func (s *JsonTestSuite) verifyStructure(expectedFiles, expectedDirs []string) {
 	var actualFiles, actualDirs []string
 

--- a/internal/parser/json_parser_test.go
+++ b/internal/parser/json_parser_test.go
@@ -1,0 +1,278 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jpwallace22/seed/internal/ctx"
+	logMock "github.com/jpwallace22/seed/pkg/logger/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type JsonTestSuite struct {
+	suite.Suite
+	logger  *logMock.MockLogger
+	parser  Parser
+	tempDir string
+}
+
+func (s *JsonTestSuite) SetupTest() {
+	var err error
+	s.tempDir, err = os.MkdirTemp("", "parser_test_*")
+	s.Require().NoError(err)
+	s.Require().NoError(os.Chdir(s.tempDir))
+
+	s.logger = logMock.New()
+	testCtx := ctx.SeedContext{
+		Logger: s.logger,
+	}
+	s.parser = NewJSONParser(testCtx)
+}
+
+func (s *JsonTestSuite) TearDownTestSuite() {
+	os.RemoveAll(s.tempDir)
+}
+
+func (s *JsonTestSuite) TestEmptyInput() {
+	s.Run("empty input should error", func() {
+		err := s.parser.ParseTree("")
+		s.Error(err, "Expected error for empty input")
+	})
+}
+
+func (s *JsonTestSuite) TestInvalidJSON() {
+	s.Run("invalid JSON should error", func() {
+		err := s.parser.ParseTree("not json")
+		s.Error(err, "Expected error for invalid JSON")
+	})
+
+	s.Run("incomplete JSON should error", func() {
+		err := s.parser.ParseTree(`[{"type":"directory","name":"root"`)
+		s.Error(err, "Expected error for incomplete JSON")
+	})
+}
+
+func (s *JsonTestSuite) TestSimpleStructure() {
+	input := `[
+		{"type":"directory","name":"root","contents":[
+			{"type":"directory","name":"dir1"},
+			{"type":"directory","name":"dir2","contents":[
+				{"type":"file","name":"file.txt"}
+			]}
+		]},
+		{"type":"report","directories":3,"files":1}
+	]`
+
+	expectedFiles := []string{"root/dir2/file.txt"}
+	expectedDirs := []string{"root", "root/dir1", "root/dir2"}
+
+	s.Run("create directory structure", func() {
+		s.Require().NoError(s.parser.ParseTree(input))
+		s.verifyStructure(expectedFiles, expectedDirs)
+	})
+}
+
+func (s *JsonTestSuite) TestComplexStructure() {
+	input := `[
+		{"type":"directory","name":"project","contents":[
+			{"type":"directory","name":"src","contents":[
+				{"type":"file","name":"main.go"},
+				{"type":"directory","name":"utils","contents":[
+					{"type":"file","name":"helper.go"}
+				]}
+			]},
+			{"type":"directory","name":"tests","contents":[
+				{"type":"file","name":"main_test.go"},
+				{"type":"directory","name":"utils","contents":[
+					{"type":"file","name":"helper_test.go"}
+				]}
+			]}
+		]},
+		{"type":"report","directories":5,"files":4}
+	]`
+
+	expectedFiles := []string{
+		"project/src/main.go",
+		"project/src/utils/helper.go",
+		"project/tests/main_test.go",
+		"project/tests/utils/helper_test.go",
+	}
+	expectedDirs := []string{
+		"project",
+		"project/src",
+		"project/src/utils",
+		"project/tests",
+		"project/tests/utils",
+	}
+
+	s.Run("create nested directory structure", func() {
+		s.Require().NoError(s.parser.ParseTree(input))
+		s.verifyStructure(expectedFiles, expectedDirs)
+	})
+}
+
+func (s *JsonTestSuite) TestDeepNesting() {
+	input := `[
+		{"type":"directory","name":"root","contents":[
+			{"type":"directory","name":"level1","contents":[
+				{"type":"directory","name":"level2","contents":[
+					{"type":"directory","name":"level3","contents":[
+						{"type":"file","name":"deep.txt"}
+					]},
+					{"type":"file","name":"file2.txt"}
+				]},
+				{"type":"file","name":"file1.txt"}
+			]},
+			{"type":"directory","name":"sibling","contents":[
+				{"type":"file","name":"nephew.txt"}
+			]}
+		]},
+		{"type":"report","directories":5,"files":4}
+	]`
+
+	expectedFiles := []string{
+		"root/level1/level2/level3/deep.txt",
+		"root/level1/level2/file2.txt",
+		"root/level1/file1.txt",
+		"root/sibling/nephew.txt",
+	}
+	expectedDirs := []string{
+		"root",
+		"root/level1",
+		"root/level1/level2",
+		"root/level1/level2/level3",
+		"root/sibling",
+	}
+
+	s.Run("create deeply nested structure", func() {
+		s.Require().NoError(s.parser.ParseTree(input))
+		s.verifyStructure(expectedFiles, expectedDirs)
+
+		deepFile := filepath.Join(s.tempDir, "root/level1/level2/level3/deep.txt")
+		s.FileExists(deepFile)
+		s.DirExists(filepath.Join(s.tempDir, "root/level1/level2/level3"))
+	})
+}
+
+func (s *JsonTestSuite) TestMultipleSiblings() {
+	input := `[
+		{"type":"directory","name":"project","contents":[
+			{"type":"directory","name":"src","contents":[
+				{"type":"file","name":"file1.txt"},
+				{"type":"file","name":"file2.txt"},
+				{"type":"file","name":"file3.txt"}
+			]},
+			{"type":"directory","name":"test","contents":[
+				{"type":"file","name":"test1.txt"},
+				{"type":"file","name":"test2.txt"},
+				{"type":"file","name":"test3.txt"}
+			]}
+		]},
+		{"type":"report","directories":3,"files":6}
+	]`
+
+	expectedFiles := []string{
+		"project/src/file1.txt",
+		"project/src/file2.txt",
+		"project/src/file3.txt",
+		"project/test/test1.txt",
+		"project/test/test2.txt",
+		"project/test/test3.txt",
+	}
+	expectedDirs := []string{
+		"project",
+		"project/src",
+		"project/test",
+	}
+
+	s.Run("create structure with multiple siblings", func() {
+		s.Require().NoError(s.parser.ParseTree(input))
+		s.verifyStructure(expectedFiles, expectedDirs)
+
+		for _, file := range []string{"file1.txt", "file2.txt", "file3.txt"} {
+			s.FileExists(filepath.Join(s.tempDir, "project/src", file))
+		}
+		for _, file := range []string{"test1.txt", "test2.txt", "test3.txt"} {
+			s.FileExists(filepath.Join(s.tempDir, "project/test", file))
+		}
+	})
+}
+
+func (s *JsonTestSuite) TestReportValidation() {
+	s.Run("incorrect file count should error", func() {
+		input := `[
+			{"type":"directory","name":"root","contents":[
+				{"type":"file","name":"file1.txt"}
+			]},
+			{"type":"report","directories":1,"files":2}
+		]`
+		err := s.parser.ParseTree(input)
+		s.Error(err, "Expected error for incorrect file count in report")
+	})
+
+	s.Run("incorrect directory count should error", func() {
+		input := `[
+			{"type":"directory","name":"root","contents":[
+				{"type":"directory","name":"dir1"}
+			]},
+			{"type":"report","directories":3,"files":0}
+		]`
+		err := s.parser.ParseTree(input)
+		s.Error(err, "Expected error for incorrect directory count in report")
+	})
+}
+
+func (s *JsonTestSuite) TestMissingFields() {
+	s.Run("missing type should error", func() {
+		input := `[
+			{"name":"root","contents":[
+				{"type":"file","name":"file1.txt"}
+			]}
+		]`
+		err := s.parser.ParseTree(input)
+		s.Error(err, "Expected error for missing type field")
+	})
+
+	s.Run("missing name should error", func() {
+		input := `[
+			{"type":"directory","contents":[
+				{"type":"file","name":"file1.txt"}
+			]}
+		]`
+		err := s.parser.ParseTree(input)
+		s.Error(err, "Expected error for missing name field")
+	})
+}
+
+func (s *JsonTestSuite) verifyStructure(expectedFiles, expectedDirs []string) {
+	var actualFiles, actualDirs []string
+
+	err := filepath.Walk(s.tempDir, func(path string, info os.FileInfo, err error) error {
+		s.Require().NoError(err)
+		if path == s.tempDir {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(s.tempDir, path)
+		s.Require().NoError(err)
+
+		// Normalize path for windows support
+		relPath = filepath.ToSlash(relPath)
+
+		if info.IsDir() {
+			actualDirs = append(actualDirs, relPath)
+		} else {
+			actualFiles = append(actualFiles, relPath)
+		}
+		return nil
+	})
+	s.Require().NoError(err)
+
+	s.ElementsMatch(expectedFiles, actualFiles, "Files created don't match expected")
+	s.ElementsMatch(expectedDirs, actualDirs, "Directories created don't match expected")
+}
+
+func TestJSONSuite(t *testing.T) {
+	suite.Run(t, new(JsonTestSuite))
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -21,6 +21,7 @@ type TreeNode struct {
 
 // func NewParser(ctx ctx.SeedContext) Parser {
 
+// This should move to a new module for filesystems, its breaking single job pattern
 func createFileSystem(node *TreeNode, parentPath string, logger logger.Logger) error {
 	if node == nil {
 		return nil

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,0 +1,68 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/jpwallace22/seed/pkg/logger"
+)
+
+type Parser interface {
+	ParseTree(string) error
+}
+
+type TreeNode struct {
+	name     string
+	children []*TreeNode
+	isFile   bool
+	depth    int
+}
+
+// func NewParser(ctx ctx.SeedContext) Parser {
+
+func createFileSystem(node *TreeNode, parentPath string, logger logger.Logger) error {
+	if node == nil {
+		return nil
+	}
+	permissions := os.FileMode(0755)
+
+	currentPath := parentPath
+	if node.name != "." {
+		currentPath = filepath.Join(parentPath, node.name)
+	}
+
+	// create current node unless it's the "." root
+	if node.name != "." {
+		if node.isFile {
+			// ensure parent directory exists
+			parentDir := filepath.Dir(currentPath)
+			if err := os.MkdirAll(parentDir, permissions); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", parentDir, err)
+			}
+
+			// create file
+			f, err := os.Create(currentPath)
+			if err != nil {
+				return fmt.Errorf("failed to create file %s: %w", currentPath, err)
+			}
+
+			f.Close()
+			logger.Info("Planted file: " + currentPath)
+		} else {
+			if err := os.MkdirAll(currentPath, permissions); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", currentPath, err)
+			}
+			logger.Info("Planted directory: " + currentPath)
+		}
+	}
+
+	// loop through children with the correct parent path
+	for _, child := range node.children {
+		if err := createFileSystem(child, currentPath, logger); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/parser/tree_parser_test.go
+++ b/internal/parser/tree_parser_test.go
@@ -33,7 +33,7 @@ func (s *ParserTestSuite) SetupTest() {
 	testCtx := ctx.SeedContext{
 		Logger: s.logger,
 	}
-	s.parser = New(testCtx)
+	s.parser = NewTreeParser(testCtx)
 }
 
 func (s *ParserTestSuite) TearDownTestSuite() {
@@ -42,7 +42,7 @@ func (s *ParserTestSuite) TearDownTestSuite() {
 
 func (s *ParserTestSuite) TestEmptyInput() {
 	s.Run("empty input should error", func() {
-		err := s.parser.ParseTreeString("")
+		err := s.parser.ParseTree("")
 		s.Error(err, "Expected error for empty input")
 	})
 }
@@ -60,7 +60,7 @@ root
 	expectedDirs := []string{"root"}
 
 	s.Run("create tree with prefix", func() {
-		s.Require().NoError(s.parser.ParseTreeString(input))
+		s.Require().NoError(s.parser.ParseTree(input))
 		s.verifyStructure(expectedFiles, expectedDirs)
 	})
 }
@@ -75,7 +75,7 @@ func (s *ParserTestSuite) TestSimpleStructure() {
 	expectedDirs := []string{"root", "root/dir1", "root/dir2"}
 
 	s.Run("create directory structure", func() {
-		s.Require().NoError(s.parser.ParseTreeString(input))
+		s.Require().NoError(s.parser.ParseTree(input))
 		s.verifyStructure(expectedFiles, expectedDirs)
 	})
 }
@@ -90,7 +90,7 @@ func (s *ParserTestSuite) TestStripsTrailingSlashes() {
 	expectedDirs := []string{"root", "root/dir1", "root/dir2"}
 
 	s.Run("create directory structure", func() {
-		s.Require().NoError(s.parser.ParseTreeString(input))
+		s.Require().NoError(s.parser.ParseTree(input))
 		s.verifyStructure(expectedFiles, expectedDirs)
 	})
 }
@@ -121,7 +121,7 @@ func (s *ParserTestSuite) TestComplexStructure() {
 	}
 
 	s.Run("create nested directory structure", func() {
-		s.Require().NoError(s.parser.ParseTreeString(input))
+		s.Require().NoError(s.parser.ParseTree(input))
 		s.verifyStructure(expectedFiles, expectedDirs)
 	})
 }
@@ -153,7 +153,7 @@ func (s *ParserTestSuite) TestDotRoot() {
 	}
 
 	s.Run("create structure with dot root", func() {
-		s.Require().NoError(s.parser.ParseTreeString(input))
+		s.Require().NoError(s.parser.ParseTree(input))
 		s.verifyStructure(expectedFiles, expectedDirs)
 
 		// Additional checks for correct nesting
@@ -186,7 +186,7 @@ func (s *ParserTestSuite) TestRealWorldExample() {
 	}
 
 	s.Run("create real world structure", func() {
-		s.Require().NoError(s.parser.ParseTreeString(input))
+		s.Require().NoError(s.parser.ParseTree(input))
 		s.verifyStructure(expectedFiles, expectedDirs)
 	})
 }
@@ -217,7 +217,7 @@ func (s *ParserTestSuite) TestDeepNesting() {
 	}
 
 	s.Run("create deeply nested structure", func() {
-		s.Require().NoError(s.parser.ParseTreeString(input))
+		s.Require().NoError(s.parser.ParseTree(input))
 		s.verifyStructure(expectedFiles, expectedDirs)
 
 		// Verify specific deep nesting
@@ -255,7 +255,7 @@ func (s *ParserTestSuite) TestMultipleSiblings() {
 	}
 
 	s.Run("create structure with multiple siblings", func() {
-		s.Require().NoError(s.parser.ParseTreeString(input))
+		s.Require().NoError(s.parser.ParseTree(input))
 		s.verifyStructure(expectedFiles, expectedDirs)
 
 		// Verify sibling files are in correct directories

--- a/internal/runner/root.go
+++ b/internal/runner/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/jpwallace22/seed/cmd/flags"
 	"github.com/jpwallace22/seed/internal/ctx"
 	"github.com/jpwallace22/seed/internal/parser"
 	"github.com/spf13/cobra"
@@ -15,46 +16,13 @@ const (
 	msgSuccess = "Your directory tree has grown successfully!"
 )
 
-type Format string
-
-const (
-	Tree Format = "tree"
-	JSON Format = "json"
-	YAML Format = "yaml"
-)
-
-func (f Format) String() string {
-	return string(f)
-}
-
-func (f *Format) Set(value string) error {
-	switch Format(value) {
-	case Tree, JSON, YAML:
-		*f = Format(value)
-		return nil
-	default:
-		return fmt.Errorf("invalid format %q, must be one of: tree, json, yaml", value)
-	}
-}
-
-func (f Format) Type() string {
-	return "format"
-}
-
-type RootFlags struct {
-	FilePath      string
-	Format        Format
-	FromClipboard bool
-}
-
 type RootRunner struct {
 	clipboard clipboard.Clipboard
 	parser    parser.Parser
 	ctx       ctx.SeedContext
 }
 
-func NewRootRunner(cobra *cobra.Command, silent bool) Runner[RootFlags] {
-	ctx := ctx.Build(cobra, silent)
+func NewRootRunner(cobra *cobra.Command, ctx *ctx.SeedContext) Runner[flags.RootFlags] {
 	return &RootRunner{
 		ctx:       *ctx,
 		clipboard: clipboard.New(),
@@ -62,8 +30,9 @@ func NewRootRunner(cobra *cobra.Command, silent bool) Runner[RootFlags] {
 	}
 }
 
-func (r *RootRunner) Run(flags RootFlags, args []string) error {
+func (r *RootRunner) Run(args []string) error {
 	logger := r.ctx.Logger
+	flags := r.ctx.Flags.Root
 
 	switch {
 	case flags.FromClipboard:

--- a/internal/runner/root.go
+++ b/internal/runner/root.go
@@ -58,7 +58,7 @@ func NewRootRunner(cobra *cobra.Command, silent bool) Runner[RootFlags] {
 	return &RootRunner{
 		ctx:       *ctx,
 		clipboard: clipboard.New(),
-		parser:    parser.New(*ctx),
+		parser:    parser.NewTreeParser(*ctx),
 	}
 }
 
@@ -82,7 +82,7 @@ func (r *RootRunner) Run(flags RootFlags, args []string) error {
 
 	case len(args) > 0:
 		logger.Log("Sprouting directories from seed: %s", args[0])
-		if err := r.parser.ParseTreeString(args[0]); err != nil {
+		if err := r.parser.ParseTree(args[0]); err != nil {
 			return fmt.Errorf("unable to parse the tree structure: %w", err)
 		}
 		logger.Success(msgSuccess)
@@ -99,7 +99,7 @@ func (r *RootRunner) parseFromFile(path string) error {
 	}
 
 	r.ctx.Logger.Log("Sowing the seeds of " + filepath.Base(path) + "...")
-	if err := r.parser.ParseTreeString(string(data)); err != nil {
+	if err := r.parser.ParseTree(string(data)); err != nil {
 		return fmt.Errorf("unable to parse the tree structure: %w", err)
 	}
 	return nil
@@ -113,7 +113,7 @@ func (r *RootRunner) parseFromClipboard() error {
 
 	r.ctx.Logger.Log("Planting from clipboard...")
 
-	if err := r.parser.ParseTreeString(text); err != nil {
+	if err := r.parser.ParseTree(text); err != nil {
 		return fmt.Errorf("unable to parse the tree structure: %w", err)
 	}
 	return nil

--- a/internal/runner/root.go
+++ b/internal/runner/root.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/jpwallace22/seed/cmd/flags"
 	"github.com/jpwallace22/seed/internal/ctx"
 	"github.com/jpwallace22/seed/internal/parser"
 	"github.com/spf13/cobra"
@@ -22,11 +21,12 @@ type RootRunner struct {
 	ctx       ctx.SeedContext
 }
 
-func NewRootRunner(cobra *cobra.Command, ctx *ctx.SeedContext) Runner[flags.RootFlags] {
+func NewRootRunner(cobra *cobra.Command, ctx *ctx.SeedContext) Runner {
+	parser, _ := parser.NewParser(ctx, parser.WithFormat(ctx.Flags.Root.Format))
 	return &RootRunner{
 		ctx:       *ctx,
 		clipboard: clipboard.New(),
-		parser:    parser.NewTreeParser(*ctx),
+		parser:    parser,
 	}
 }
 

--- a/internal/runner/root_test.go
+++ b/internal/runner/root_test.go
@@ -34,7 +34,7 @@ type MockParser struct {
 	mock.Mock
 }
 
-func (m *MockParser) ParseTreeString(tree string) error {
+func (m *MockParser) ParseTree(tree string) error {
 	args := m.Called(tree)
 	return args.Error(0)
 }
@@ -49,7 +49,7 @@ func buildTestRunner(silent bool) (*RootRunner, *MockClipboard, *MockParser) {
 
 	testCtx := &ctx.SeedContext{
 		Logger: mockLogger,
-		GlobalFlags: ctx.GlobalFlags{
+		Config: ctx.Config{
 			Silent: silent,
 		},
 		Cobra: mockCmd,
@@ -92,7 +92,7 @@ func TestNewRunner(t *testing.T) {
 			assert.NotNil(t, runner)
 			assert.NotNil(t, rootRunner.ctx)
 			assert.NotNil(t, rootRunner.clipboard)
-			assert.Equal(t, tt.config.Silent, rootRunner.ctx.GlobalFlags.Silent)
+			assert.Equal(t, tt.config.Silent, rootRunner.ctx.Config.Silent)
 		})
 	}
 }
@@ -132,7 +132,7 @@ func TestClipboardOperations(t *testing.T) {
 
 			mockClipboard.On("PasteText").Return(tt.clipContent, tt.clipError)
 			if !tt.expectError {
-				mockParser.On("ParseTreeString", tt.clipContent).Return(nil)
+				mockParser.On("ParseTree", tt.clipContent).Return(nil)
 			}
 
 			err := runner.Run(tt.flags, tt.args)
@@ -196,7 +196,7 @@ func TestFileOperations(t *testing.T) {
 				err := os.WriteFile(tt.flags.FilePath, []byte(tt.fileContent), 0644)
 				defer os.Remove(tt.flags.FilePath)
 				assert.NoError(t, err)
-				mockParser.On("ParseTreeString", tt.fileContent).Return(nil)
+				mockParser.On("ParseTree", tt.fileContent).Return(nil)
 			}
 
 			err := runner.Run(tt.flags, tt.args)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1,6 +1,6 @@
 package runner
 
-type Runner[T any] interface {
+type Runner interface {
 	Run(args []string) error
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1,7 +1,7 @@
 package runner
 
 type Runner[T any] interface {
-	Run(flags T, args []string) error
+	Run(args []string) error
 }
 
 type Config struct {


### PR DESCRIPTION
## Add JSON format support for directory structure creation

This PR adds support for creating directory structures from JSON input, providing a more programmatic and machine-readable alternative to the existing tree-based format.

### Features

- New JSON parser that handles both files and directory structures
- Support for deeply nested directory structures
- Optional report object for structure validation
- Command line flags `-F json` and `--format json` for JSON input
- Comprehensive validation of JSON structure and field requirements
- Error handling for invalid JSON formats and structure mismatches

### Implementation Details

- Added `JSONParser` implementation that processes JSON input into directory structures
- JSON schema validation ensures all required fields (`type`, `name`) are present
- Optional `contents` array for directories allows nested structures
- Report validation compares actual vs reported file/directory counts
- Robust error handling for common scenarios:
  - Empty input
  - Invalid JSON syntax
  - Missing required fields
  - Incorrect structure counts in report object

### Testing

Added comprehensive test suite covering:
- Empty and invalid inputs
- Simple and complex directory structures
- Deep nesting scenarios
- Multiple sibling directories/files
- Report validation
- Missing field validation
- Structure creation without report object

### Documentation

- Added JSON format section to README
- Included example JSON structures
- Documented command line usage
- Added validation rules and requirements

### Example Usage

```json
[
  {
    "type": "directory",
    "name": "project",
    "contents": [
      {
        "type": "directory",
        "name": "src",
        "contents": [
          {
            "type": "file",
            "name": "main.go"
          }
        ]
      }
    ]
  },
  {
    "type": "report",
    "directories": 2,
    "files": 1
  }
]
```

### Command Line

```bash
seed -F json structure.json
# or
seed --format json '{"type":"directory","name":"root","contents":[...]}'
```
